### PR TITLE
Remove ref to DockerEng from StateMachine

### DIFF
--- a/cmd/nshore/app/states.go
+++ b/cmd/nshore/app/states.go
@@ -156,11 +156,6 @@ func (pl *BlueprintPipeline) afterInactivate(e *fsm.Event) {
 }
 
 func (pl *BlueprintPipeline) afterStart(e *fsm.Event) {
-	for stage := range pl.StagesStates {
-		log.Printf("#BlueprintPipeline,#afterStart Create stage %s", stage)
-		// Call to DockerEng
-		pl.StagesStates[stage] = StageStateCreated
-	}
 	pl.State = BlueprintStateProvision
 }
 


### PR DESCRIPTION
According to the "nshore run PIPELINE blueprint" diagram
the API module is responsible for interacting with DockerEng